### PR TITLE
Hotfix/pseudo instructions addi error

### DIFF
--- a/isa/generate.bat
+++ b/isa/generate.bat
@@ -1,0 +1,2 @@
+@echo off
+for /r %%F in (*.yaml) do call python ..\scripts\y2j.py "%%F"

--- a/isa/riscv.isa/rv32i/config.json
+++ b/isa/riscv.isa/rv32i/config.json
@@ -1,685 +1,690 @@
 {
+    "alignment-behavior": "relaxed",
+    "signed-representation": "twos-complement",
+    "instructions": [
+        {
+            "mnemonic": "simusleep",
+            "format": "custom",
+            "operand length": [
+                32
+            ],
+            "length": 32,
+            "key": {
+                "opcode": -1
+            }
+        },
+        {
+            "mnemonic": "simucrash",
+            "format": "custom",
+            "length": 32,
+            "key": {
+                "opcode": -1
+            }
+        },
+        {
+            "mnemonic": "lui",
+            "format": "U",
+            "operand length": [
+                0,
+                20
+            ],
+            "length": 32,
+            "key": {
+                "opcode": 55
+            }
+        },
+        {
+            "mnemonic": "auipc",
+            "format": "U",
+            "operand length": [
+                0,
+                20
+            ],
+            "length": 32,
+            "key": {
+                "opcode": 23
+            }
+        },
+        {
+            "mnemonic": "jal",
+            "format": "UJ",
+            "operand length": [
+                0,
+                20
+            ],
+            "length": 32,
+            "key": {
+                "opcode": 111
+            }
+        },
+        {
+            "mnemonic": "jalr",
+            "format": "I",
+            "operand length": [
+                0,
+                0,
+                12
+            ],
+            "length": 32,
+            "key": {
+                "opcode": 103,
+                "funct3": 0
+            }
+        },
+        {
+            "mnemonic": "beq",
+            "format": "SB",
+            "operand length": [
+                0,
+                0,
+                12
+            ],
+            "length": 32,
+            "key": {
+                "opcode": 99,
+                "funct3": 0
+            }
+        },
+        {
+            "mnemonic": "bne",
+            "format": "SB",
+            "operand length": [
+                0,
+                0,
+                12
+            ],
+            "length": 32,
+            "key": {
+                "opcode": 99,
+                "funct3": 1
+            }
+        },
+        {
+            "mnemonic": "blt",
+            "format": "SB",
+            "operand length": [
+                0,
+                0,
+                12
+            ],
+            "length": 32,
+            "key": {
+                "opcode": 99,
+                "funct3": 4
+            }
+        },
+        {
+            "mnemonic": "bge",
+            "format": "SB",
+            "operand length": [
+                0,
+                0,
+                12
+            ],
+            "length": 32,
+            "key": {
+                "opcode": 99,
+                "funct3": 5
+            }
+        },
+        {
+            "mnemonic": "bltu",
+            "format": "SB",
+            "operand length": [
+                0,
+                0,
+                12
+            ],
+            "length": 32,
+            "key": {
+                "opcode": 99,
+                "funct3": 6
+            }
+        },
+        {
+            "mnemonic": "bgeu",
+            "format": "SB",
+            "operand length": [
+                0,
+                0,
+                12
+            ],
+            "length": 32,
+            "key": {
+                "opcode": 99,
+                "funct3": 7
+            }
+        },
+        {
+            "mnemonic": "lb",
+            "format": "I",
+            "operand length": [
+                0,
+                0,
+                12
+            ],
+            "length": 32,
+            "key": {
+                "opcode": 3,
+                "funct3": 0
+            }
+        },
+        {
+            "mnemonic": "lh",
+            "format": "I",
+            "operand length": [
+                0,
+                0,
+                12
+            ],
+            "length": 32,
+            "key": {
+                "opcode": 3,
+                "funct3": 1
+            }
+        },
+        {
+            "mnemonic": "lw",
+            "format": "I",
+            "operand length": [
+                0,
+                0,
+                12
+            ],
+            "length": 32,
+            "key": {
+                "opcode": 3,
+                "funct3": 2
+            }
+        },
+        {
+            "mnemonic": "lbu",
+            "format": "I",
+            "operand length": [
+                0,
+                0,
+                12
+            ],
+            "length": 32,
+            "key": {
+                "opcode": 3,
+                "funct3": 4
+            }
+        },
+        {
+            "mnemonic": "lhu",
+            "format": "I",
+            "operand length": [
+                0,
+                0,
+                12
+            ],
+            "length": 32,
+            "key": {
+                "opcode": 3,
+                "funct3": 5
+            }
+        },
+        {
+            "mnemonic": "sb",
+            "format": "S",
+            "operand length": [
+                0,
+                0,
+                12
+            ],
+            "length": 32,
+            "key": {
+                "opcode": 35,
+                "funct3": 0
+            }
+        },
+        {
+            "mnemonic": "sh",
+            "format": "S",
+            "operand length": [
+                0,
+                0,
+                12
+            ],
+            "length": 32,
+            "key": {
+                "opcode": 35,
+                "funct3": 1
+            }
+        },
+        {
+            "mnemonic": "sw",
+            "format": "S",
+            "operand length": [
+                0,
+                0,
+                12
+            ],
+            "length": 32,
+            "key": {
+                "opcode": 35,
+                "funct3": 2
+            }
+        },
+        {
+            "mnemonic": "addi",
+            "format": "I",
+            "operand length": [
+                0,
+                0,
+                12
+            ],
+            "length": 32,
+            "key": {
+                "opcode": 19,
+                "funct3": 0
+            }
+        },
+        {
+            "mnemonic": "slti",
+            "format": "I",
+            "operand length": [
+                0,
+                0,
+                12
+            ],
+            "length": 32,
+            "key": {
+                "opcode": 19,
+                "funct3": 2
+            }
+        },
+        {
+            "mnemonic": "sltiu",
+            "format": "I",
+            "operand length": [
+                0,
+                0,
+                12
+            ],
+            "length": 32,
+            "key": {
+                "opcode": 19,
+                "funct3": 3
+            }
+        },
+        {
+            "mnemonic": "xori",
+            "format": "I",
+            "operand length": [
+                0,
+                0,
+                12
+            ],
+            "length": 32,
+            "key": {
+                "opcode": 19,
+                "funct3": 4
+            }
+        },
+        {
+            "mnemonic": "ori",
+            "format": "I",
+            "operand length": [
+                0,
+                0,
+                12
+            ],
+            "length": 32,
+            "key": {
+                "opcode": 19,
+                "funct3": 6
+            }
+        },
+        {
+            "mnemonic": "andi",
+            "format": "I",
+            "operand length": [
+                0,
+                0,
+                12
+            ],
+            "length": 32,
+            "key": {
+                "opcode": 19,
+                "funct3": 7
+            }
+        },
+        {
+            "mnemonic": "slli",
+            "format": "R",
+            "operand length": [
+                0,
+                0,
+                12
+            ],
+            "length": 32,
+            "key": {
+                "funct7": 0,
+                "opcode": 19,
+                "funct3": 1
+            }
+        },
+        {
+            "mnemonic": "srli",
+            "format": "R",
+            "operand length": [
+                0,
+                0,
+                12
+            ],
+            "length": 32,
+            "key": {
+                "funct7": 0,
+                "opcode": 19,
+                "funct3": 5
+            }
+        },
+        {
+            "mnemonic": "srai",
+            "format": "R",
+            "operand length": [
+                0,
+                0,
+                12
+            ],
+            "length": 32,
+            "key": {
+                "funct7": 32,
+                "opcode": 19,
+                "funct3": 5
+            }
+        },
+        {
+            "mnemonic": "add",
+            "format": "R",
+            "length": 32,
+            "key": {
+                "funct7": 0,
+                "opcode": 51,
+                "funct3": 0
+            }
+        },
+        {
+            "mnemonic": "sub",
+            "format": "R",
+            "length": 32,
+            "key": {
+                "funct7": 32,
+                "opcode": 51,
+                "funct3": 0
+            }
+        },
+        {
+            "mnemonic": "sll",
+            "format": "R",
+            "length": 32,
+            "key": {
+                "funct7": 0,
+                "opcode": 51,
+                "funct3": 1
+            }
+        },
+        {
+            "mnemonic": "slt",
+            "format": "R",
+            "length": 32,
+            "key": {
+                "funct7": 0,
+                "opcode": 51,
+                "funct3": 2
+            }
+        },
+        {
+            "mnemonic": "sltu",
+            "format": "R",
+            "length": 32,
+            "key": {
+                "funct7": 0,
+                "opcode": 51,
+                "funct3": 3
+            }
+        },
+        {
+            "mnemonic": "xor",
+            "format": "R",
+            "length": 32,
+            "key": {
+                "funct7": 0,
+                "opcode": 51,
+                "funct3": 4
+            }
+        },
+        {
+            "mnemonic": "srl",
+            "format": "R",
+            "length": 32,
+            "key": {
+                "funct7": 0,
+                "opcode": 51,
+                "funct3": 5
+            }
+        },
+        {
+            "mnemonic": "sra",
+            "format": "R",
+            "length": 32,
+            "key": {
+                "funct7": 32,
+                "opcode": 51,
+                "funct3": 5
+            }
+        },
+        {
+            "mnemonic": "or",
+            "format": "R",
+            "length": 32,
+            "key": {
+                "funct7": 0,
+                "opcode": 51,
+                "funct3": 6
+            }
+        },
+        {
+            "mnemonic": "and",
+            "format": "R",
+            "length": 32,
+            "key": {
+                "funct7": 7,
+                "opcode": 51,
+                "funct3": 0
+            }
+        }
+    ],
     "units": [
         {
             "registers": [
                 {
-                    "size": 32,
-                    "name": "x0",
                     "id": 0,
                     "alias": "zero",
-                    "constant": "0x0"
+                    "constant": "0x0",
+                    "size": 32,
+                    "name": "x0"
                 },
                 {
+                    "id": 1,
                     "size": 32,
-                    "name": "x1",
-                    "id": 1
+                    "name": "x1"
                 },
                 {
+                    "id": 2,
                     "size": 32,
-                    "name": "x2",
-                    "id": 2
+                    "name": "x2"
                 },
                 {
+                    "id": 3,
                     "size": 32,
-                    "name": "x3",
-                    "id": 3
+                    "name": "x3"
                 },
                 {
+                    "id": 4,
                     "size": 32,
-                    "name": "x4",
-                    "id": 4
+                    "name": "x4"
                 },
                 {
+                    "id": 5,
                     "size": 32,
-                    "name": "x5",
-                    "id": 5
+                    "name": "x5"
                 },
                 {
+                    "id": 6,
                     "size": 32,
-                    "name": "x6",
-                    "id": 6
+                    "name": "x6"
                 },
                 {
+                    "id": 7,
                     "size": 32,
-                    "name": "x7",
-                    "id": 7
+                    "name": "x7"
                 },
                 {
+                    "id": 8,
                     "size": 32,
-                    "name": "x8",
-                    "id": 8
+                    "name": "x8"
                 },
                 {
+                    "id": 9,
                     "size": 32,
-                    "name": "x9",
-                    "id": 9
+                    "name": "x9"
                 },
                 {
+                    "id": 10,
                     "size": 32,
-                    "name": "x10",
-                    "id": 10
+                    "name": "x10"
                 },
                 {
+                    "id": 11,
                     "size": 32,
-                    "name": "x11",
-                    "id": 11
+                    "name": "x11"
                 },
                 {
+                    "id": 12,
                     "size": 32,
-                    "name": "x12",
-                    "id": 12
+                    "name": "x12"
                 },
                 {
+                    "id": 13,
                     "size": 32,
-                    "name": "x13",
-                    "id": 13
+                    "name": "x13"
                 },
                 {
+                    "id": 14,
                     "size": 32,
-                    "name": "x14",
-                    "id": 14
+                    "name": "x14"
                 },
                 {
+                    "id": 15,
                     "size": 32,
-                    "name": "x15",
-                    "id": 15
+                    "name": "x15"
                 },
                 {
+                    "id": 16,
                     "size": 32,
-                    "name": "x16",
-                    "id": 16
+                    "name": "x16"
                 },
                 {
+                    "id": 17,
                     "size": 32,
-                    "name": "x17",
-                    "id": 17
+                    "name": "x17"
                 },
                 {
+                    "id": 18,
                     "size": 32,
-                    "name": "x18",
-                    "id": 18
+                    "name": "x18"
                 },
                 {
+                    "id": 19,
                     "size": 32,
-                    "name": "x19",
-                    "id": 19
+                    "name": "x19"
                 },
                 {
+                    "id": 20,
                     "size": 32,
-                    "name": "x20",
-                    "id": 20
+                    "name": "x20"
                 },
                 {
+                    "id": 21,
                     "size": 32,
-                    "name": "x21",
-                    "id": 21
+                    "name": "x21"
                 },
                 {
+                    "id": 22,
                     "size": 32,
-                    "name": "x22",
-                    "id": 22
+                    "name": "x22"
                 },
                 {
+                    "id": 23,
                     "size": 32,
-                    "name": "x23",
-                    "id": 23
+                    "name": "x23"
                 },
                 {
+                    "id": 24,
                     "size": 32,
-                    "name": "x24",
-                    "id": 24
+                    "name": "x24"
                 },
                 {
+                    "id": 25,
                     "size": 32,
-                    "name": "x25",
-                    "id": 25
+                    "name": "x25"
                 },
                 {
+                    "id": 26,
                     "size": 32,
-                    "name": "x26",
-                    "id": 26
+                    "name": "x26"
                 },
                 {
+                    "id": 27,
                     "size": 32,
-                    "name": "x27",
-                    "id": 27
+                    "name": "x27"
                 },
                 {
+                    "id": 28,
                     "size": 32,
-                    "name": "x28",
-                    "id": 28
+                    "name": "x28"
                 },
                 {
+                    "id": 29,
                     "size": 32,
-                    "name": "x29",
-                    "id": 29
+                    "name": "x29"
                 },
                 {
+                    "id": 30,
                     "size": 32,
-                    "name": "x30",
-                    "id": 30
+                    "name": "x30"
                 },
                 {
+                    "id": 31,
                     "size": 32,
-                    "name": "x31",
-                    "id": 31
+                    "name": "x31"
                 },
                 {
-                    "size": 32,
-                    "name": "pc",
                     "id": 32,
-                    "type": "program-counter"
+                    "size": 32,
+                    "type": "program-counter",
+                    "name": "pc"
                 }
             ],
             "name": "cpu"
         }
     ],
-    "instructions": [
-        {
-            "operand length": [
-                32
-            ],
-            "key": {
-                "opcode": -1
-            },
-            "length": 32,
-            "format": "custom",
-            "mnemonic": "simusleep"
-        },
-        {
-            "key": {
-                "opcode": -1
-            },
-            "length": 32,
-            "format": "custom",
-            "mnemonic": "simucrash"
-        },
-        {
-            "operand length": [
-                0,
-                20
-            ],
-            "key": {
-                "opcode": 55
-            },
-            "length": 32,
-            "format": "U",
-            "mnemonic": "lui"
-        },
-        {
-            "operand length": [
-                0,
-                20
-            ],
-            "key": {
-                "opcode": 23
-            },
-            "length": 32,
-            "format": "U",
-            "mnemonic": "auipc"
-        },
-        {
-            "operand length": [
-                0,
-                20
-            ],
-            "key": {
-                "opcode": 111
-            },
-            "length": 32,
-            "format": "UJ",
-            "mnemonic": "jal"
-        },
-        {
-            "operand length": [
-                0,
-                0,
-                12
-            ],
-            "key": {
-                "funct3": 0,
-                "opcode": 103
-            },
-            "length": 32,
-            "format": "I",
-            "mnemonic": "jalr"
-        },
-        {
-            "operand length": [
-                0,
-                0,
-                12
-            ],
-            "key": {
-                "funct3": 0,
-                "opcode": 99
-            },
-            "length": 32,
-            "format": "SB",
-            "mnemonic": "beq"
-        },
-        {
-            "operand length": [
-                0,
-                0,
-                12
-            ],
-            "key": {
-                "funct3": 1,
-                "opcode": 99
-            },
-            "length": 32,
-            "format": "SB",
-            "mnemonic": "bne"
-        },
-        {
-            "operand length": [
-                0,
-                0,
-                12
-            ],
-            "key": {
-                "funct3": 4,
-                "opcode": 99
-            },
-            "length": 32,
-            "format": "SB",
-            "mnemonic": "blt"
-        },
-        {
-            "operand length": [
-                0,
-                0,
-                12
-            ],
-            "key": {
-                "funct3": 5,
-                "opcode": 99
-            },
-            "length": 32,
-            "format": "SB",
-            "mnemonic": "bge"
-        },
-        {
-            "operand length": [
-                0,
-                0,
-                12
-            ],
-            "key": {
-                "funct3": 6,
-                "opcode": 99
-            },
-            "length": 32,
-            "format": "SB",
-            "mnemonic": "bltu"
-        },
-        {
-            "operand length": [
-                0,
-                0,
-                12
-            ],
-            "key": {
-                "funct3": 7,
-                "opcode": 99
-            },
-            "length": 32,
-            "format": "SB",
-            "mnemonic": "bgeu"
-        },
-        {
-            "operand length": [
-                0,
-                0,
-                12
-            ],
-            "key": {
-                "funct3": 0,
-                "opcode": 3
-            },
-            "length": 32,
-            "format": "I",
-            "mnemonic": "lb"
-        },
-        {
-            "operand length": [
-                0,
-                0,
-                12
-            ],
-            "key": {
-                "funct3": 1,
-                "opcode": 3
-            },
-            "length": 32,
-            "format": "I",
-            "mnemonic": "lh"
-        },
-        {
-            "operand length": [
-                0,
-                0,
-                12
-            ],
-            "key": {
-                "funct3": 2,
-                "opcode": 3
-            },
-            "length": 32,
-            "format": "I",
-            "mnemonic": "lw"
-        },
-        {
-            "operand length": [
-                0,
-                0,
-                12
-            ],
-            "key": {
-                "funct3": 4,
-                "opcode": 3
-            },
-            "length": 32,
-            "format": "I",
-            "mnemonic": "lbu"
-        },
-        {
-            "operand length": [
-                0,
-                0,
-                12
-            ],
-            "key": {
-                "funct3": 5,
-                "opcode": 3
-            },
-            "length": 32,
-            "format": "I",
-            "mnemonic": "lhu"
-        },
-        {
-            "operand length": [
-                0,
-                0,
-                12
-            ],
-            "key": {
-                "funct3": 0,
-                "opcode": 35
-            },
-            "length": 32,
-            "format": "S",
-            "mnemonic": "sb"
-        },
-        {
-            "operand length": [
-                0,
-                0,
-                12
-            ],
-            "key": {
-                "funct3": 1,
-                "opcode": 35
-            },
-            "length": 32,
-            "format": "S",
-            "mnemonic": "sh"
-        },
-        {
-            "operand length": [
-                0,
-                0,
-                12
-            ],
-            "key": {
-                "funct3": 2,
-                "opcode": 35
-            },
-            "length": 32,
-            "format": "S",
-            "mnemonic": "sw"
-        },
-        {
-            "operand length": [
-                0,
-                0,
-                12
-            ],
-            "key": {
-                "funct3": 0,
-                "opcode": 19
-            },
-            "length": 32,
-            "format": "I",
-            "mnemonic": "addi"
-        },
-        {
-            "operand length": [
-                0,
-                0,
-                12
-            ],
-            "key": {
-                "funct3": 2,
-                "opcode": 19
-            },
-            "length": 32,
-            "format": "I",
-            "mnemonic": "slti"
-        },
-        {
-            "operand length": [
-                0,
-                0,
-                12
-            ],
-            "key": {
-                "funct3": 3,
-                "opcode": 19
-            },
-            "length": 32,
-            "format": "I",
-            "mnemonic": "sltiu"
-        },
-        {
-            "operand length": [
-                0,
-                0,
-                12
-            ],
-            "key": {
-                "funct3": 4,
-                "opcode": 19
-            },
-            "length": 32,
-            "format": "I",
-            "mnemonic": "xori"
-        },
-        {
-            "operand length": [
-                0,
-                0,
-                12
-            ],
-            "key": {
-                "funct3": 6,
-                "opcode": 19
-            },
-            "length": 32,
-            "format": "I",
-            "mnemonic": "ori"
-        },
-        {
-            "operand length": [
-                0,
-                0,
-                12
-            ],
-            "key": {
-                "funct3": 7,
-                "opcode": 19
-            },
-            "length": 32,
-            "format": "I",
-            "mnemonic": "andi"
-        },
-        {
-            "operand length": [
-                0,
-                0,
-                12
-            ],
-            "key": {
-                "funct7": 0,
-                "funct3": 1,
-                "opcode": 19
-            },
-            "length": 32,
-            "format": "R",
-            "mnemonic": "slli"
-        },
-        {
-            "operand length": [
-                0,
-                0,
-                12
-            ],
-            "key": {
-                "funct7": 0,
-                "funct3": 5,
-                "opcode": 19
-            },
-            "length": 32,
-            "format": "R",
-            "mnemonic": "srli"
-        },
-        {
-            "operand length": [
-                0,
-                0,
-                12
-            ],
-            "key": {
-                "funct7": 32,
-                "funct3": 5,
-                "opcode": 19
-            },
-            "length": 32,
-            "format": "R",
-            "mnemonic": "srai"
-        },
-        {
-            "key": {
-                "funct7": 0,
-                "funct3": 0,
-                "opcode": 51
-            },
-            "length": 32,
-            "format": "R",
-            "mnemonic": "add"
-        },
-        {
-            "key": {
-                "funct7": 32,
-                "funct3": 0,
-                "opcode": 51
-            },
-            "length": 32,
-            "format": "R",
-            "mnemonic": "sub"
-        },
-        {
-            "key": {
-                "funct7": 0,
-                "funct3": 1,
-                "opcode": 51
-            },
-            "length": 32,
-            "format": "R",
-            "mnemonic": "sll"
-        },
-        {
-            "key": {
-                "funct7": 0,
-                "funct3": 2,
-                "opcode": 51
-            },
-            "length": 32,
-            "format": "R",
-            "mnemonic": "slt"
-        },
-        {
-            "key": {
-                "funct7": 0,
-                "funct3": 3,
-                "opcode": 51
-            },
-            "length": 32,
-            "format": "R",
-            "mnemonic": "sltu"
-        },
-        {
-            "key": {
-                "funct7": 0,
-                "funct3": 4,
-                "opcode": 51
-            },
-            "length": 32,
-            "format": "R",
-            "mnemonic": "xor"
-        },
-        {
-            "key": {
-                "funct7": 0,
-                "funct3": 5,
-                "opcode": 51
-            },
-            "length": 32,
-            "format": "R",
-            "mnemonic": "srl"
-        },
-        {
-            "key": {
-                "funct7": 32,
-                "funct3": 5,
-                "opcode": 51
-            },
-            "length": 32,
-            "format": "R",
-            "mnemonic": "sra"
-        },
-        {
-            "key": {
-                "funct7": 0,
-                "funct3": 6,
-                "opcode": 51
-            },
-            "length": 32,
-            "format": "R",
-            "mnemonic": "or"
-        },
-        {
-            "key": {
-                "funct7": 7,
-                "funct3": 0,
-                "opcode": 51
-            },
-            "length": 32,
-            "format": "R",
-            "mnemonic": "and"
-        }
-    ],
-    "word-size": 32,
-    "endianness": "little",
     "name": "rv32i",
+    "endianness": "little",
+    "word-size": 32,
     "builtin-macros": [
-        ".macro la, rd, symbol\nauipc \\rd, ((\\symbol >> 12) & 0xfffff)\naddi \\rd, \\rd, (\\symbol & 0xfff)\n.endm\n",
-        ".macro lbg, rd, symbol\nauipc \\rd, ((\\symbol >> 12) & 0xfffff)\nlb \\rd, \\rd, (\\symbol & 0xfff)\n.endm\n",
-        ".macro lhg, rd, symbol\nauipc \\rd, ((\\symbol >> 12) & 0xfffff)\nlh \\rd, \\rd, (\\symbol & 0xfff)\n.endm\n",
-        ".macro lwg, rd, symbol\nauipc \\rd, ((\\symbol >> 12) & 0xfffff)\nlw \\rd, \\rd, (\\symbol & 0xfff)\n.endm\n",
+        ".macro la, rd, symbol\nauipc \\rd, (((\\symbol) >> 12) + (((\\symbol) >> 11) & 1)) & ((1 << 20) - 1)\naddi \\rd, \\rd, ((\\symbol) & ((1 << 11) - 1)) - ((\\symbol) & (1 << 11))\n.endm\n",
+        ".macro lbg, rd, symbol\nauipc \\rd, (((\\symbol) >> 12) + (((\\symbol) >> 11) & 1)) & ((1 << 20) - 1)\nlb \\rd, \\rd, ((\\symbol) & ((1 << 11) - 1)) - ((\\symbol) & (1 << 11))\n.endm\n",
+        ".macro lhg, rd, symbol\nauipc \\rd, (((\\symbol) >> 12) + (((\\symbol) >> 11) & 1)) & ((1 << 20) - 1)\nlh \\rd, \\rd, ((\\symbol) & ((1 << 11) - 1)) - ((\\symbol) & (1 << 11))\n.endm\n",
+        ".macro lwg, rd, symbol\nauipc \\rd, (((\\symbol) >> 12) + (((\\symbol) >> 11) & 1)) & ((1 << 20) - 1)\nlw \\rd, \\rd, ((\\symbol) & ((1 << 11) - 1)) - ((\\symbol) & (1 << 11))\n.endm\n",
+        ".macro sbg, rd, symbol, rt\nauipc \\rt, (((\\symbol) >> 12) + (((\\symbol) >> 11) & 1)) & ((1 << 20) - 1)\nsb \\rt, \\rd, ((\\symbol) & ((1 << 11) - 1)) - ((\\symbol) & (1 << 11))\n.endm\n",
+        ".macro shg, rd, symbol, rt\nauipc \\rt, (((\\symbol) >> 12) + (((\\symbol) >> 11) & 1)) & ((1 << 20) - 1)\nsh \\rt, \\rd, ((\\symbol) & ((1 << 11) - 1)) - ((\\symbol) & (1 << 11))\n.endm\n",
+        ".macro swg, rd, symbol, rt\nauipc \\rt, (((\\symbol) >> 12) + (((\\symbol) >> 11) & 1)) & ((1 << 20) - 1)\nsw \\rt, \\rd, ((\\symbol) & ((1 << 11) - 1)) - ((\\symbol) & (1 << 11))\n.endm\n",
         ".macro nop\naddi x0, x0, 0\n.endm\n",
-        ".macro li, rd, imm\nlui \\rd, ((\\imm >> 12) & 0xfffff)\naddi \\rd, \\rd, (\\imm & 0xfff)\n.endm\n",
+        ".macro li, rd, imm\nlui \\rd, (((\\imm) >> 12) + (((\\imm) >> 11) & 1)) & ((1 << 20) - 1)\naddi \\rd, \\rd, ((\\imm) & ((1 << 11) - 1)) - ((\\imm) & (1 << 11))\n.endm\n",
         ".macro mv, rd, rs\naddi \\rd, \\rs, 0\n.endm\n",
         ".macro not, rd, rs\nxori \\rd, \\rs, -1\n.endm\n",
         ".macro neg, rd, rs\nsub \\rd, x0, \\rs\n.endm\n",
@@ -698,10 +703,8 @@
         ".macro jr, rs\njalr x0, \\rs, 0\n.endm\n",
         ".macro jalr, rs\njalr x1, \\rs, 0\n.endm\n",
         ".macro ret\njalr x0, x1, 0\n.endm\n",
-        ".macro call, offset\nauipc x6, ((\\offset >> 12) & 0xfffff)\njalr x1, x6, (\\offset & 0xfff)\n.endm\n",
-        ".macro tail, offset\nauipc x6, ((\\offset >> 12) & 0xfffff)\njalr x0, x6, (\\offset & 0xfff)\n.endm\n"
+        ".macro call, offset\nauipc x6, (((\\offset) >> 12) + (((\\offset) >> 11) & 1)) & ((1 << 20) - 1)\njalr x1, x6, ((\\offset) & ((1 << 11) - 1)) - ((\\offset) & (1 << 11))\n.endm\n",
+        ".macro tail, offset\nauipc x6, (((\\offset) >> 12) + (((\\offset) >> 11) & 1)) & ((1 << 20) - 1)\njalr x0, x6, ((\\offset) & ((1 << 11) - 1)) - ((\\offset) & (1 << 11))\n.endm\n"
     ],
-    "signed-representation": "twos-complement",
-    "alignment-behavior": "relaxed",
     "byte-size": 8
 }

--- a/isa/riscv.isa/rv32i/config.yaml
+++ b/isa/riscv.isa/rv32i/config.yaml
@@ -360,13 +360,32 @@ instructions:
       funct7: 7
 
 # To explain the complex mechanism of calculating an address:
-# We got the problem that every immediate except auipc and lui is signed, no exceptions.
-# This means, calling for example li r1 2048 should actually cause a compile error if you stick to the RISC-V spec, version 2.1 where just the lower 12 bits are taken as an immediate.
-# To work around this problem, we do the following (let imm be the immediate that was put in by the user):
-# * if the lower 12 bits (viewed unsigned) are less than 2048 (i.e. imm[11] is zero), we put imm[12:31] into our lui instruction and imm[0:11] into our addi instruction. And imm[0:11] is guaranteed less than 2048, so we can simply take imm[0:10].
-# * if this is not the case, we take imm[12:31] and increment it. Now, we calculate the difference: imm - (imm[12:31] + 2^12) = imm[0:11] - 2^12 = 2^11 + imm[0:10] - 2^12 = imm[0:10] - 2^11 = imm[0:10] - 2048. As imm[0:10] is at least 0 and at max 2047, we have -2048 as the minimum value which just turns out to still be in our 12 bit range.
+# We got the problem that every immediate except auipc and lui is signed,
+# no exceptions. This means, calling for example li r1 2048 should actually
+# cause a compile error if you stick to the RISC-V spec, version 2.1 where
+# just the lower 12 bits are taken as an immediate.
+# To work around this problem, we do the following
+# (let imm be the immediate that was put in by the user):
+# * if the lower 12 bits (viewed unsigned) are less than 2048 (i.e. imm[11]
+#   is zero), we put imm[12:31] into our lui instruction and imm[0:11] into
+#   our addi instruction. And imm[0:11] is guaranteed less than 2048, so we
+#   can simply take imm[0:10].
+# * if this is not the case, we take imm[12:31] and increment it. Now, we
+#   calculate the difference: imm - (imm[12:31] + 2^12) = imm[0:11] - 2^12
+#   = 2^11 + imm[0:10] - 2^12 = imm[0:10] - 2^11 = imm[0:10] - 2048. As
+#   imm[0:10] is at least 0 and at max 2047, we have -2048 as the minimum
+#   value which just turns out to still be in our 12 bit range.
 # Summing it up:
-# We take imm[12:31] + imm[11]. Now we still have to handle the corner case that imm[12:31] is the max value that can be stored in these bytes, in this case imm[12:31] + imm[11] has to be zero. So we take (imm[12:31] + imm[11]) & (2^20 - 1). For the lower 12 bits, we simply do imm[0:10] - imm[11] * 2048.
+# We take imm[12:31] + imm[11]. Now we still have to handle the corner case
+# that imm[12:31] is the max value that can be stored in these bytes, in this
+# case imm[12:31] + imm[11] has to be zero. So we take
+#
+# (imm[12:31] + imm[11]) & (2^20 - 1)
+#
+# For the lower 12 bits, we simply do
+#
+# imm[0:10] - imm[11] * 2048
+#
 
 builtin-macros:
   - |

--- a/isa/riscv.isa/rv32i/config.yaml
+++ b/isa/riscv.isa/rv32i/config.yaml
@@ -359,51 +359,59 @@ instructions:
       funct3: 0
       funct7: 7
 
+# To explain the complex mechanism of calculating an address:
+# We got the problem that every immediate except auipc and lui is signed, no exceptions.
+# This means, calling for example li r1 2048 should actually cause a compile error if you stick to the RISC-V spec, version 2.1 where just the lower 12 bits are taken as an immediate.
+# To work around this problem, we do the following (let imm be the immediate that was put in by the user):
+# * if the lower 12 bits (viewed unsigned) are less than 2048 (i.e. imm[11] is zero), we put imm[12:31] into our lui instruction and imm[0:11] into our addi instruction. And imm[0:11] is guaranteed less than 2048, so we can simply take imm[0:10].
+# * if this is not the case, we take imm[12:31] and increment it. Now, we calculate the difference: imm - (imm[12:31] + 2^12) = imm[0:11] - 2^12 = 2^11 + imm[0:10] - 2^12 = imm[0:10] - 2^11 = imm[0:10] - 2048. As imm[0:10] is at least 0 and at max 2047, we have -2048 as the minimum value which just turns out to still be in our 12 bit range.
+# Summing it up:
+# We take imm[12:31] + imm[11]. Now we still have to handle the corner case that imm[12:31] is the max value that can be stored in these bytes, in this case imm[12:31] + imm[11] has to be zero. So we take (imm[12:31] + imm[11]) & (2^20 - 1). For the lower 12 bits, we simply do imm[0:10] - imm[11] * 2048.
+
 builtin-macros:
   - |
     .macro la, rd, symbol
-    auipc \rd, ((\symbol >> 12) & 0xfffff)
-    addi \rd, \rd, (\symbol & 0xfff)
+    auipc \rd, (((\symbol) >> 12) + (((\symbol) >> 11) & 1)) & ((1 << 20) - 1)
+    addi \rd, \rd, ((\symbol) & ((1 << 11) - 1)) - ((\symbol) & (1 << 11))
     .endm
   - |
     .macro lbg, rd, symbol
-    auipc \rd, ((\symbol >> 12) & 0xfffff)
-    lb \rd, \rd, (\symbol & 0xfff)
+    auipc \rd, (((\symbol) >> 12) + (((\symbol) >> 11) & 1)) & ((1 << 20) - 1)
+    lb \rd, \rd, ((\symbol) & ((1 << 11) - 1)) - ((\symbol) & (1 << 11))
     .endm
   - |
     .macro lhg, rd, symbol
-    auipc \rd, ((\symbol >> 12) & 0xfffff)
-    lh \rd, \rd, (\symbol & 0xfff)
+    auipc \rd, (((\symbol) >> 12) + (((\symbol) >> 11) & 1)) & ((1 << 20) - 1)
+    lh \rd, \rd, ((\symbol) & ((1 << 11) - 1)) - ((\symbol) & (1 << 11))
     .endm
   - |
     .macro lwg, rd, symbol
-    auipc \rd, ((\symbol >> 12) & 0xfffff)
-    lw \rd, \rd, (\symbol & 0xfff)
+    auipc \rd, (((\symbol) >> 12) + (((\symbol) >> 11) & 1)) & ((1 << 20) - 1)
+    lw \rd, \rd, ((\symbol) & ((1 << 11) - 1)) - ((\symbol) & (1 << 11))
     .endm
-# Disabled due to issues with parser
-#  - |
-#    .macro sbg, rd, symbol, rt
-#    auipc \rt, ((\symbol >> 12) & 0xfffff)
-#    sb \rt, \rd, (\symbol & 0xfff)
-#    .endm
-#  - |
-#    .macro shg, rd, symbol, rt
-#    auipc \rt, ((\symbol >> 12) & 0xfffff)
-#    sh \rt, \rd, (\symbol & 0xfff)
-#    .endm
-#  - |
-#    .macro swg, rd, symbol, rt
-#    auipc \rt, ((\symbol >> 12) & 0xfffff)
-#    sw \rt, \rd, (\symbol & 0xfff)
-#    .endm
+  - |
+    .macro sbg, rd, symbol, rt
+    auipc \rt, (((\symbol) >> 12) + (((\symbol) >> 11) & 1)) & ((1 << 20) - 1)
+    sb \rt, \rd, ((\symbol) & ((1 << 11) - 1)) - ((\symbol) & (1 << 11))
+    .endm
+  - |
+    .macro shg, rd, symbol, rt
+    auipc \rt, (((\symbol) >> 12) + (((\symbol) >> 11) & 1)) & ((1 << 20) - 1)
+    sh \rt, \rd, ((\symbol) & ((1 << 11) - 1)) - ((\symbol) & (1 << 11))
+    .endm
+  - |
+    .macro swg, rd, symbol, rt
+    auipc \rt, (((\symbol) >> 12) + (((\symbol) >> 11) & 1)) & ((1 << 20) - 1)
+    sw \rt, \rd, ((\symbol) & ((1 << 11) - 1)) - ((\symbol) & (1 << 11))
+    .endm
   - |
     .macro nop
     addi x0, x0, 0
     .endm
   - |
     .macro li, rd, imm
-    lui \rd, ((\imm >> 12) & 0xfffff)
-    addi \rd, \rd, (\imm & 0xfff)
+    lui \rd, (((\imm) >> 12) + (((\imm) >> 11) & 1)) & ((1 << 20) - 1)
+    addi \rd, \rd, ((\imm) & ((1 << 11) - 1)) - ((\imm) & (1 << 11))
     .endm
   - |
     .macro mv, rd, rs
@@ -479,13 +487,13 @@ builtin-macros:
     .endm
   - |
     .macro call, offset
-    auipc x6, ((\offset >> 12) & 0xfffff)
-    jalr x1, x6, (\offset & 0xfff)
+    auipc x6, (((\offset) >> 12) + (((\offset) >> 11) & 1)) & ((1 << 20) - 1)
+    jalr x1, x6, ((\offset) & ((1 << 11) - 1)) - ((\offset) & (1 << 11))
     .endm
   - |
     .macro tail, offset
-    auipc x6, ((\offset >> 12) & 0xfffff)
-    jalr x0, x6, (\offset & 0xfff)
+    auipc x6, (((\offset) >> 12) + (((\offset) >> 11) & 1)) & ((1 << 20) - 1)
+    jalr x0, x6, ((\offset) & ((1 << 11) - 1)) - ((\offset) & (1 << 11))
     .endm
 units:
   - name: cpu

--- a/isa/riscv.isa/rv64i/config.json
+++ b/isa/riscv.isa/rv64i/config.json
@@ -1,369 +1,370 @@
 {
     "reset-units": true,
-    "units": [
-        {
-            "registers": [
-                {
-                    "size": 64,
-                    "name": "x0",
-                    "id": 0,
-                    "alias": "zero",
-                    "constant": "0x0"
-                },
-                {
-                    "size": 64,
-                    "name": "x1",
-                    "id": 1
-                },
-                {
-                    "size": 64,
-                    "name": "x2",
-                    "id": 2
-                },
-                {
-                    "size": 64,
-                    "name": "x3",
-                    "id": 3
-                },
-                {
-                    "size": 64,
-                    "name": "x4",
-                    "id": 4
-                },
-                {
-                    "size": 64,
-                    "name": "x5",
-                    "id": 5
-                },
-                {
-                    "size": 64,
-                    "name": "x6",
-                    "id": 6
-                },
-                {
-                    "size": 64,
-                    "name": "x7",
-                    "id": 7
-                },
-                {
-                    "size": 64,
-                    "name": "x8",
-                    "id": 8
-                },
-                {
-                    "size": 64,
-                    "name": "x9",
-                    "id": 9
-                },
-                {
-                    "size": 64,
-                    "name": "x10",
-                    "id": 10
-                },
-                {
-                    "size": 64,
-                    "name": "x11",
-                    "id": 11
-                },
-                {
-                    "size": 64,
-                    "name": "x12",
-                    "id": 12
-                },
-                {
-                    "size": 64,
-                    "name": "x13",
-                    "id": 13
-                },
-                {
-                    "size": 64,
-                    "name": "x14",
-                    "id": 14
-                },
-                {
-                    "size": 64,
-                    "name": "x15",
-                    "id": 15
-                },
-                {
-                    "size": 64,
-                    "name": "x16",
-                    "id": 16
-                },
-                {
-                    "size": 64,
-                    "name": "x17",
-                    "id": 17
-                },
-                {
-                    "size": 64,
-                    "name": "x18",
-                    "id": 18
-                },
-                {
-                    "size": 64,
-                    "name": "x19",
-                    "id": 19
-                },
-                {
-                    "size": 64,
-                    "name": "x20",
-                    "id": 20
-                },
-                {
-                    "size": 64,
-                    "name": "x21",
-                    "id": 21
-                },
-                {
-                    "size": 64,
-                    "name": "x22",
-                    "id": 22
-                },
-                {
-                    "size": 64,
-                    "name": "x23",
-                    "id": 23
-                },
-                {
-                    "size": 64,
-                    "name": "x24",
-                    "id": 24
-                },
-                {
-                    "size": 64,
-                    "name": "x25",
-                    "id": 25
-                },
-                {
-                    "size": 64,
-                    "name": "x26",
-                    "id": 26
-                },
-                {
-                    "size": 64,
-                    "name": "x27",
-                    "id": 27
-                },
-                {
-                    "size": 64,
-                    "name": "x28",
-                    "id": 28
-                },
-                {
-                    "size": 64,
-                    "name": "x29",
-                    "id": 29
-                },
-                {
-                    "size": 64,
-                    "name": "x30",
-                    "id": 30
-                },
-                {
-                    "size": 64,
-                    "name": "x31",
-                    "id": 31
-                },
-                {
-                    "size": 64,
-                    "name": "pc",
-                    "id": 32,
-                    "type": "program-counter"
-                }
-            ],
-            "name": "cpu"
-        }
+    "name": "rv64i",
+    "builtin-macros": [
+        ".macro ldg, rd, symbol\nauipc \\rd, (((\\symbol) >> 12) + (((\\symbol) >> 11) & 1)) & ((1 << 20) - 1)\nld \\rd, \\rd, ((\\symbol) & ((1 << 11) - 1)) - ((\\symbol) & (1 << 11))\n.endm\n",
+        ".macro sdg, rd, symbol, rt\nauipc \\rt, (((\\symbol) >> 12) + (((\\symbol) >> 11) & 1)) & ((1 << 20) - 1)\nsd \\rt, \\rd, ((\\symbol) & ((1 << 11) - 1)) - ((\\symbol) & (1 << 11))\n.endm\n",
+        ".macro negw, rd, rs\nsubw \\rd, x0, \\rs\n.endm\n",
+        ".macro sext.w, rd, rs\naddiw \\rd, \\rs, 0\n.endm\n"
     ],
+    "word-size": 64,
     "extends": "rv32i",
     "instructions": [
         {
+            "mnemonic": "lwu",
             "operand length": [
                 0,
                 0,
                 12
             ],
-            "key": {
-                "funct3": 6,
-                "opcode": 3
-            },
             "length": 32,
-            "format": "I",
-            "mnemonic": "lwu"
+            "key": {
+                "opcode": 3,
+                "funct3": 6
+            },
+            "format": "I"
         },
         {
+            "mnemonic": "ld",
             "operand length": [
                 0,
                 0,
                 12
             ],
-            "key": {
-                "funct3": 3,
-                "opcode": 3
-            },
             "length": 32,
-            "format": "I",
-            "mnemonic": "ld"
+            "key": {
+                "opcode": 3,
+                "funct3": 3
+            },
+            "format": "I"
         },
         {
+            "mnemonic": "sd",
             "operand length": [
                 0,
                 0,
                 12
             ],
-            "key": {
-                "funct3": 3,
-                "opcode": 35
-            },
             "length": 32,
-            "format": "S",
-            "mnemonic": "sd"
+            "key": {
+                "opcode": 35,
+                "funct3": 3
+            },
+            "format": "S"
         },
         {
+            "mnemonic": "slli",
             "operand length": [
                 0,
                 0,
                 12
             ],
+            "length": 32,
             "key": {
-                "funct7": 0,
+                "opcode": 19,
                 "funct3": 1,
-                "opcode": 19
+                "funct7": 0
             },
-            "length": 32,
-            "format": "R",
-            "mnemonic": "slli"
+            "format": "R"
         },
         {
+            "mnemonic": "srai",
             "operand length": [
                 0,
                 0,
                 12
             ],
+            "length": 32,
             "key": {
-                "funct7": 1,
+                "opcode": 19,
                 "funct3": 5,
-                "opcode": 19
+                "funct7": 1
             },
-            "length": 32,
-            "format": "R",
-            "mnemonic": "srai"
+            "format": "R"
         },
         {
+            "mnemonic": "addiw",
             "operand length": [
                 0,
                 0,
                 12
             ],
-            "key": {
-                "funct3": 0,
-                "opcode": 27
-            },
             "length": 32,
-            "format": "I",
-            "mnemonic": "addiw"
+            "key": {
+                "opcode": 27,
+                "funct3": 0
+            },
+            "format": "I"
         },
         {
+            "mnemonic": "slliw",
             "operand length": [
                 0,
                 0,
                 12
             ],
+            "length": 32,
             "key": {
-                "funct7": 0,
+                "opcode": 27,
                 "funct3": 1,
-                "opcode": 27
+                "funct7": 0
             },
-            "length": 32,
-            "format": "R",
-            "mnemonic": "slliw"
+            "format": "R"
         },
         {
+            "mnemonic": "srliw",
             "operand length": [
                 0,
                 0,
                 12
             ],
-            "key": {
-                "funct7": 0,
-                "funct3": 5,
-                "opcode": 27
-            },
             "length": 32,
-            "format": "R",
-            "mnemonic": "srliw"
+            "key": {
+                "opcode": 27,
+                "funct3": 5,
+                "funct7": 0
+            },
+            "format": "R"
         },
         {
+            "mnemonic": "sraiw",
             "operand length": [
                 0,
                 0,
                 12
             ],
+            "length": 32,
             "key": {
-                "funct7": 32,
+                "opcode": 27,
                 "funct3": 5,
-                "opcode": 27
+                "funct7": 32
             },
-            "length": 32,
-            "format": "R",
-            "mnemonic": "sraiw"
+            "format": "R"
         },
         {
+            "mnemonic": "addw",
+            "length": 32,
             "key": {
-                "funct7": 0,
+                "opcode": 59,
                 "funct3": 0,
-                "opcode": 59
+                "funct7": 0
             },
-            "length": 32,
-            "format": "R",
-            "mnemonic": "addw"
+            "format": "R"
         },
         {
+            "mnemonic": "subw",
+            "length": 32,
             "key": {
-                "funct7": 32,
+                "opcode": 59,
                 "funct3": 0,
-                "opcode": 59
+                "funct7": 32
             },
-            "length": 32,
-            "format": "R",
-            "mnemonic": "subw"
+            "format": "R"
         },
         {
+            "mnemonic": "sllw",
+            "length": 32,
             "key": {
-                "funct7": 0,
+                "opcode": 59,
                 "funct3": 1,
-                "opcode": 59
+                "funct7": 0
             },
-            "length": 32,
-            "format": "R",
-            "mnemonic": "sllw"
+            "format": "R"
         },
         {
-            "key": {
-                "funct7": 0,
-                "funct3": 5,
-                "opcode": 59
-            },
+            "mnemonic": "srlw",
             "length": 32,
-            "format": "R",
-            "mnemonic": "srlw"
+            "key": {
+                "opcode": 59,
+                "funct3": 5,
+                "funct7": 0
+            },
+            "format": "R"
         },
         {
-            "key": {
-                "funct7": 32,
-                "funct3": 5,
-                "opcode": 59
-            },
+            "mnemonic": "sraw",
             "length": 32,
-            "format": "R",
-            "mnemonic": "sraw"
+            "key": {
+                "opcode": 59,
+                "funct3": 5,
+                "funct7": 32
+            },
+            "format": "R"
         }
     ],
-    "word-size": 64,
-    "name": "rv64i",
-    "builtin-macros": [
-        ".macro ldg, rd, symbol\nauipc \\rd, ((\\symbol >> 12) & 0xfffff)\nld \\rd, \\rd, (\\symbol & 0xfff)\n.endm\n",
-        ".macro negw, rd, rs\nsubw \\rd, x0, \\rs\n.endm\n",
-        ".macro sext.w, rd, rs\naddiw \\rd, \\rs, 0\n.endm\n"
+    "units": [
+        {
+            "name": "cpu",
+            "registers": [
+                {
+                    "id": 0,
+                    "name": "x0",
+                    "size": 64,
+                    "constant": "0x0",
+                    "alias": "zero"
+                },
+                {
+                    "id": 1,
+                    "name": "x1",
+                    "size": 64
+                },
+                {
+                    "id": 2,
+                    "name": "x2",
+                    "size": 64
+                },
+                {
+                    "id": 3,
+                    "name": "x3",
+                    "size": 64
+                },
+                {
+                    "id": 4,
+                    "name": "x4",
+                    "size": 64
+                },
+                {
+                    "id": 5,
+                    "name": "x5",
+                    "size": 64
+                },
+                {
+                    "id": 6,
+                    "name": "x6",
+                    "size": 64
+                },
+                {
+                    "id": 7,
+                    "name": "x7",
+                    "size": 64
+                },
+                {
+                    "id": 8,
+                    "name": "x8",
+                    "size": 64
+                },
+                {
+                    "id": 9,
+                    "name": "x9",
+                    "size": 64
+                },
+                {
+                    "id": 10,
+                    "name": "x10",
+                    "size": 64
+                },
+                {
+                    "id": 11,
+                    "name": "x11",
+                    "size": 64
+                },
+                {
+                    "id": 12,
+                    "name": "x12",
+                    "size": 64
+                },
+                {
+                    "id": 13,
+                    "name": "x13",
+                    "size": 64
+                },
+                {
+                    "id": 14,
+                    "name": "x14",
+                    "size": 64
+                },
+                {
+                    "id": 15,
+                    "name": "x15",
+                    "size": 64
+                },
+                {
+                    "id": 16,
+                    "name": "x16",
+                    "size": 64
+                },
+                {
+                    "id": 17,
+                    "name": "x17",
+                    "size": 64
+                },
+                {
+                    "id": 18,
+                    "name": "x18",
+                    "size": 64
+                },
+                {
+                    "id": 19,
+                    "name": "x19",
+                    "size": 64
+                },
+                {
+                    "id": 20,
+                    "name": "x20",
+                    "size": 64
+                },
+                {
+                    "id": 21,
+                    "name": "x21",
+                    "size": 64
+                },
+                {
+                    "id": 22,
+                    "name": "x22",
+                    "size": 64
+                },
+                {
+                    "id": 23,
+                    "name": "x23",
+                    "size": 64
+                },
+                {
+                    "id": 24,
+                    "name": "x24",
+                    "size": 64
+                },
+                {
+                    "id": 25,
+                    "name": "x25",
+                    "size": 64
+                },
+                {
+                    "id": 26,
+                    "name": "x26",
+                    "size": 64
+                },
+                {
+                    "id": 27,
+                    "name": "x27",
+                    "size": 64
+                },
+                {
+                    "id": 28,
+                    "name": "x28",
+                    "size": 64
+                },
+                {
+                    "id": 29,
+                    "name": "x29",
+                    "size": 64
+                },
+                {
+                    "id": 30,
+                    "name": "x30",
+                    "size": 64
+                },
+                {
+                    "id": 31,
+                    "name": "x31",
+                    "size": 64
+                },
+                {
+                    "name": "pc",
+                    "type": "program-counter",
+                    "size": 64,
+                    "id": 32
+                }
+            ]
+        }
     ]
 }

--- a/isa/riscv.isa/rv64i/config.yaml
+++ b/isa/riscv.isa/rv64i/config.yaml
@@ -144,11 +144,11 @@ builtin-macros:
     auipc \rd, (((\symbol) >> 12) + (((\symbol) >> 11) & 1)) & ((1 << 20) - 1)
     ld \rd, \rd, ((\symbol) & ((1 << 11) - 1)) - ((\symbol) & (1 << 11))
     .endm
-#  - |
-#    .macro sdg, rd, symbol, rt
-#    auipc \rt, (((\symbol) >> 12) + (((\symbol) >> 11) & 1)) & ((1 << 20) - 1)
-#    sd \rt, \rd, ((\symbol) & ((1 << 11) - 1)) - ((\symbol) & (1 << 11))
-#    .endm
+  - |
+    .macro sdg, rd, symbol, rt
+    auipc \rt, (((\symbol) >> 12) + (((\symbol) >> 11) & 1)) & ((1 << 20) - 1)
+    sd \rt, \rd, ((\symbol) & ((1 << 11) - 1)) - ((\symbol) & (1 << 11))
+    .endm
   - |
     .macro negw, rd, rs
     subw \rd, x0, \rs

--- a/isa/riscv.isa/rv64i/config.yaml
+++ b/isa/riscv.isa/rv64i/config.yaml
@@ -141,13 +141,13 @@ instructions:
 builtin-macros:
   - |
     .macro ldg, rd, symbol
-    auipc \rd, ((\symbol >> 12) & 0xfffff)
-    ld \rd, \rd, (\symbol & 0xfff)
+    auipc \rd, (((\symbol) >> 12) + (((\symbol) >> 11) & 1)) & ((1 << 20) - 1)
+    ld \rd, \rd, ((\symbol) & ((1 << 11) - 1)) - ((\symbol) & (1 << 11))
     .endm
 #  - |
 #    .macro sdg, rd, symbol, rt
-#    auipc \rt, ((\symbol >> 12) & 0xfffff)
-#    sd \rt, \rd, (\symbol & 0xfff)
+#    auipc \rt, (((\symbol) >> 12) + (((\symbol) >> 11) & 1)) & ((1 << 20) - 1)
+#    sd \rt, \rd, ((\symbol) & ((1 << 11) - 1)) - ((\symbol) & (1 << 11))
 #    .endm
   - |
     .macro negw, rd, rs


### PR DESCRIPTION
This proposes a fix for the problem that for example `li x1, 2048` might result in a compiler crash, because the 2048 are out of range for a 12 bit signed immediate. Explaination how it is done in `rv32i.yaml`.

Of course, this all comes at the cost of breaking the specification in this point.

Also, this patch adds an additional batch to compile the yaml files on Windows (in case anyone needs to do that anytime soon).

I have also re-enabled the store pseudo instructions where it said that they were disabled because of a parser error (I suppose because it has four arguments... Or maybe even this one?). It should be ok to go now I think as this was corrected some issues ago.