### PR TITLE
hotfix/registers-qml-error

### DIFF
--- a/source/ui/Components/Register/FormatSelector.qml
+++ b/source/ui/Components/Register/FormatSelector.qml
@@ -25,7 +25,6 @@ ComboBox {
   id: root
 
   property var index
-  property var registerModel
   property TreeView treeView
   property alias selection: root.currentText
 

--- a/source/ui/Components/Register/Register.qml
+++ b/source/ui/Components/Register/Register.qml
@@ -22,11 +22,9 @@ import QtQuick.Controls.Styles 1.4
 import Theme 1.0
 
 Item {
-  property var model
 
   RegisterLabel {
     id: registerName
-    model: parent.model
     anchors {
       left: parent.left
       leftMargin: Theme.register.marginLeft
@@ -64,7 +62,6 @@ Item {
     id: formatSelector
     index: styleData.index
     treeView: registerTreeView
-    registerModel: registerTreeView.model
     anchors {
       right: parent.right
       rightMargin: Theme.register.marginRight

--- a/source/ui/Components/Register/RegisterComponent.qml
+++ b/source/ui/Components/Register/RegisterComponent.qml
@@ -67,9 +67,7 @@ Item {
     model: registerModel
     rowDelegate: Item { height: Theme.register.height }
 
-    itemDelegate: Register {
-      model: parent.model
-    }
+    itemDelegate: Register { }
 
     onFormatAllRegisters: {
       // Set default format to make newly loaded

--- a/source/ui/Components/Register/RegisterLabel.qml
+++ b/source/ui/Components/Register/RegisterLabel.qml
@@ -22,7 +22,6 @@ import QtQuick.Controls.Styles 1.4
 import Theme 1.0
 
 Label {
-  property var model
   text: model ? model.Title : ""
 
   color: Theme.register.label.color


### PR DESCRIPTION
Closes #278 
Stops registers from polluting console due to a temporarily undefined property.