### PR TITLE
Better support for builtin macros

### DIFF
--- a/include/parser/common/compile-error-list.hpp
+++ b/include/parser/common/compile-error-list.hpp
@@ -62,6 +62,8 @@ class CompileErrorList {
    */
   const CompileErrorVector& errors() const noexcept;
 
+  CompileErrorVector& errors() noexcept;
+
   /**
    * A helper method to determine if the list has any errors (not
    * including warnings, information).
@@ -152,6 +154,17 @@ class CompileErrorList {
             interval,
             severity});
   }
+
+  /**
+   * Adds a compile error created from the arguments to the list.
+   *
+   * \param severity The given severity of the compile error.
+   * \param interval The given code position interval where to error occured.
+   * \param message The message to record.
+   */
+  void pushCompileErrorInternal(CompileErrorSeverity severity,
+                                const CodePositionInterval& interval,
+                                const Translateable& message);
 
   /**
    * Adds a compile error created from the arguments to the list,

--- a/source/core/parsing-and-execution-unit.cpp
+++ b/source/core/parsing-and-execution-unit.cpp
@@ -84,7 +84,7 @@ void ParsingAndExecutionUnit::executeNextLine() {
 
     nextNode = _updateLineNumber(nextNode);
 
-    if (nextNode >= _filenalRepresentation.commandList().size()) break;
+    if (nextNode >= _finalRepresentation.commandList().size()) break;
 
     // Skip nodes that aren't part of the users program
   } while (_finalRepresentation.commandList()[nextNode].position().isEmpty());

--- a/source/core/parsing-and-execution-unit.cpp
+++ b/source/core/parsing-and-execution-unit.cpp
@@ -83,6 +83,9 @@ void ParsingAndExecutionUnit::executeNextLine() {
     if (!_executeNode(nextNode)) break;
 
     nextNode = _updateLineNumber(nextNode);
+
+    if (nextNode >= _filenalRepresentation.commandList().size()) break;
+
     // Skip nodes that aren't part of the users program
   } while (_finalRepresentation.commandList()[nextNode].position().isEmpty());
   _executionStopped();

--- a/source/core/parsing-and-execution-unit.cpp
+++ b/source/core/parsing-and-execution-unit.cpp
@@ -86,7 +86,7 @@ void ParsingAndExecutionUnit::executeNextLine() {
 
     if (nextNode >= _finalRepresentation.commandList().size()) break;
 
-    // Skip nodes that aren't part of the users program
+    // Skip nodes that aren't part of the user's program
   } while (_finalRepresentation.commandList()[nextNode].position().isEmpty());
   _executionStopped();
 }

--- a/source/core/parsing-and-execution-unit.cpp
+++ b/source/core/parsing-and-execution-unit.cpp
@@ -79,9 +79,12 @@ void ParsingAndExecutionUnit::execute() {
 void ParsingAndExecutionUnit::executeNextLine() {
   _stopCondition->reset();
   size_t nextNode = _findNextNode();
-  if (_executeNode(nextNode)) {
-    _updateLineNumber(nextNode);
-  }
+  do {
+    if (!_executeNode(nextNode)) break;
+
+    nextNode = _updateLineNumber(nextNode);
+    // Skip nodes that aren't part of the users program
+  } while (_finalRepresentation.commandList()[nextNode].position().isEmpty());
   _executionStopped();
 }
 

--- a/source/parser/common/compile-error-list.cpp
+++ b/source/parser/common/compile-error-list.cpp
@@ -33,6 +33,17 @@ const CompileErrorVector& CompileErrorList::errors() const noexcept {
   return _errors;
 }
 
+CompileErrorVector& CompileErrorList::errors() noexcept {
+  return _errors;
+}
+
+void CompileErrorList::pushCompileErrorInternal(
+    CompileErrorSeverity severity,
+    const CodePositionInterval& interval,
+    const Translateable& message) {
+  addRaw({std::make_shared<Translateable>(message), interval, severity});
+}
+
 // Some internal helper methods.
 namespace {
 bool existsError(const CompileErrorVector& errors,

--- a/source/parser/independent/intermediate-macro-instruction.cpp
+++ b/source/parser/independent/intermediate-macro-instruction.cpp
@@ -18,6 +18,7 @@
 
 #include "parser/independent/intermediate-macro-instruction.hpp"
 
+#include <algorithm>
 #include <cstddef>
 #include <memory>
 #include <string>
@@ -98,8 +99,36 @@ void IntermediateMacroInstruction::execute(
     CompileErrorList& errors,
     FinalCommandVector& commandOutput,
     MemoryAccess& memoryAccess) {
+  CompileErrorList innerErrors;
+  FinalCommandVector innerCommands;
   for (const auto& operation : _operations) {
-    operation->execute(immutable, errors, commandOutput, memoryAccess);
+    operation->execute(immutable, innerErrors, innerCommands, memoryAccess);
+  }
+  // If the inner commands don't have their own position, use the position of
+  // the macro call
+  if (innerCommands.size() > 0 && innerCommands[0].position().isEmpty()) {
+    commandOutput.emplace_back(innerCommands[0].node(),
+                               positionInterval(),
+                               innerCommands[0].address());
+    for (auto& error : innerErrors.errors()) {
+      errors.pushCompileErrorInternal(
+          error.severity(), positionInterval(), error.message());
+    }
+  } else {
+    if (innerCommands.size() > 0) {
+      commandOutput.push_back(std::move(innerCommands[0]));
+    }
+
+    std::move(innerErrors.errors().begin(),
+              innerErrors.errors().end(),
+              std::back_inserter(errors.errors()));
+  }
+
+  // Move rest of inner commands to commandOutput
+  if (innerCommands.size() > 1) {
+    std::move(innerCommands.begin() + 1,
+              innerCommands.end(),
+              std::back_inserter(commandOutput));
   }
 }
 

--- a/source/parser/independent/intermediate-macro-instruction.cpp
+++ b/source/parser/independent/intermediate-macro-instruction.cpp
@@ -110,18 +110,16 @@ void IntermediateMacroInstruction::execute(
     commandOutput.emplace_back(innerCommands[0].node(),
                                positionInterval(),
                                innerCommands[0].address());
-    for (const auto& error : innerErrors.errors()) {
-      errors.pushCompileErrorInternal(
-          error.severity(), positionInterval(), error.message());
-    }
   } else {
     if (innerCommands.size() > 0) {
       commandOutput.push_back(std::move(innerCommands[0]));
     }
+  }
 
-    std::move(innerErrors.errors().begin(),
-              innerErrors.errors().end(),
-              std::back_inserter(errors.errors()));
+  // Move errors to macro call position
+  for (const auto& error : innerErrors.errors()) {
+    errors.pushCompileErrorInternal(
+        error.severity(), positionInterval(), error.message());
   }
 
   // Move rest of inner commands to commandOutput

--- a/source/parser/independent/intermediate-macro-instruction.cpp
+++ b/source/parser/independent/intermediate-macro-instruction.cpp
@@ -110,7 +110,7 @@ void IntermediateMacroInstruction::execute(
     commandOutput.emplace_back(innerCommands[0].node(),
                                positionInterval(),
                                innerCommands[0].address());
-    for (auto& error : innerErrors.errors()) {
+    for (const auto& error : innerErrors.errors()) {
       errors.pushCompileErrorInternal(
           error.severity(), positionInterval(), error.message());
     }

--- a/source/ui/ui.cpp
+++ b/source/ui/ui.cpp
@@ -53,12 +53,12 @@ int Ui::runUi() {
   return _qmlApplication.exec();
 }
 
-id_t Ui::addProject(QQuickItem* tabItem,
-                    QQmlComponent* projectComponent,
-                    const QVariant& memorySizeQVariant,
-                    const QString& architecture,
-                    const QString& optionName,
-                    const QString& parser) {
+Ui::id_t Ui::addProject(QQuickItem* tabItem,
+                        QQmlComponent* projectComponent,
+                        const QVariant& memorySizeQVariant,
+                        const QString& architecture,
+                        const QString& optionName,
+                        const QString& parser) {
   ArchitectureFormula architectureFormula(architecture.toStdString());
 
   // Add all extensions which are defined for this option


### PR DESCRIPTION
Errors while parsing built-in macros are now placed at the position of the macro call.

Additionally, executeNextLine will now execute Nodes until a valid line is reached again. This means built-in macros are executed in one step.