### PR TITLE
Hotfix/editor line numbers

### DIFF
--- a/source/ui/Components/editor/Editor.qml
+++ b/source/ui/Components/editor/Editor.qml
@@ -24,6 +24,34 @@ import Theme 1.0
 import "../Common"
 import "../../Js/TextUtility.js" as TextUtility
 
+// Notes on line numbering: The editor displays macro expansions inline which
+// means that code below a macroBar expansion that was expanded (i.e. is
+// visible) has to be offset in order to accomodate the macro expansion's code.
+// To do this, blank lines are inserted. These blank lines however are not
+// considered actual lines for the user. So as far as line numbering is
+// concerened, these blank lines have the same line number as the line above
+// them. These kind of line numbers are called "display line numbers". The
+// Parser module and Core module however do not know about that kind of line
+// numbering. They use the normal line numbering that assign a sequential line
+// number even to macro blank lines. These kind of line numbers are called "raw
+// line numbers". QML interface components index their line numbers starting
+// from 0 which are called "line indexes".
+//
+// The following naming conventions are (mostly) used in this file:
+// - Display Line Numbers: Values from 1 to m with macro
+// blank lines factored out
+// (e.g. blank lines have same line number as line above). A variable refering
+// to lines not specified to be display or raw is usually type display (i.e.
+// display is default).
+// - Raw Line Numbers: Values from 1 to n with macro blank
+// lines treated as normal lines (therefore n >= m).
+// - Line Indexes: Values from 0 to k. Used by QML components and often used for
+// positioning.
+//
+// The functions `convertRawLineNumberToDisplayLineNumber` and
+// `convertDisplayLineNumberToRawLineNumber` can be used to translate between
+// both types of line numbers.
+
 ScrollView {
   id: scrollView
   verticalScrollBarPolicy: Qt.ScrollBarAsNeeded

--- a/source/ui/Components/editor/InlineMacros.qml
+++ b/source/ui/Components/editor/InlineMacros.qml
@@ -90,7 +90,7 @@ Item {
         for (var macroIndex = 0; macroIndex < macros.length; ++macroIndex) {
             var macro = macros[macroIndex];
             // Find the line for the macro expansion.
-            var linePosition = TextUtility.getPositionOfOccurence(textRegion.text, "\n", Number(macro["startLine"])+1);
+            var linePosition = TextUtility.getPositionOfOccurence(textRegion.text, "\n", Number(macro["startLine"]));
             // Create display objects (i.e. sub-editor and triangle)
             var macroDisplayObject = {};
             // Add sub-editor to display object
@@ -256,10 +256,10 @@ Item {
         // to a blank line.
         for (var macroIndex = 0; macroIndex < macros.length; ++macroIndex) {
             var clearedLineNumber = lineNumber-blankLineCount;
-            if (clearedLineNumber > Number(macros[macroIndex]["startLine"])) {
+            if (clearedLineNumber >= Number(macros[macroIndex]["startLine"])) {
                 if (macros[macroIndex]["collapsed"] === false) {
                     // Given lineNumber lies within an macro expansion's blank lines.
-                    if (clearedLineNumber <= Number(macros[macroIndex]["startLine"])+Number(macros[macroIndex]["lineCount"])) {
+                    if (clearedLineNumber < Number(macros[macroIndex]["startLine"])+Number(macros[macroIndex]["lineCount"])) {
                         return true;
                     }
                     // Save number of blank lines to filter them out when reading macro-startLine information.
@@ -280,16 +280,14 @@ Item {
       // Iterate over all macros and note down every macro blank line.
       for (var macroIndex = 0; macroIndex < macros.length; ++macroIndex) {
         var macro = macros[macroIndex];
-        // Note: startLine starts counting at 0.
         var macroRawLineNumber = Number(macro["startLine"])+blankLineCount;
         // Check if the given line number lies below a macro expansion.
-        if (macro["collapsed"] === false && rawLineNumber > (macroRawLineNumber+1)) {
+        if (macro["collapsed"] === false && rawLineNumber > macroRawLineNumber) {
           blankLineCount += Number(macro["lineCount"]);
           // If the given line number lies within a macro expansion, return position
           // of macro expansion.
-          if (rawLineNumber <= (macroRawLineNumber+1+Number(macro["lineCount"]))) {
-            // Note: startLine starts counting at 0.
-            return Number(macro["startLine"])+1;
+          if (rawLineNumber <= (macroRawLineNumber+Number(macro["lineCount"]))) {
+            return Number(macro["startLine"]);
           }
         }
       }
@@ -301,7 +299,7 @@ Item {
         var rawLineNumber = displayLineNumber;
         for (var macroIndex = 0; macroIndex < macros.length; ++macroIndex) {
             var macro = macros[macroIndex];
-            if (Number(macro["startLine"]) < displayLineNumber && macro["collapsed"] === false) {
+            if (Number(macro["startLine"]) <= displayLineNumber && macro["collapsed"] === false) {
                 rawLineNumber += Number(macro["lineCount"]);
             }
         }
@@ -317,7 +315,7 @@ Item {
         for (var i = 0; i < macroIndex; ++i) {
             insertedNewLines += (!macros[i]["collapsed"]) ? Number(macros[i]["lineCount"]) : 0;
         }
-        return TextUtility.getPositionOfOccurence(textRegion.text, "\n", Number(macro["startLine"])+insertedNewLines+1);
+        return TextUtility.getPositionOfOccurence(textRegion.text, "\n", Number(macro["startLine"])+insertedNewLines);
     }
 
 

--- a/source/ui/Components/editor/LineNumbering.qml
+++ b/source/ui/Components/editor/LineNumbering.qml
@@ -23,34 +23,6 @@ import QtQuick.Controls.Styles 1.4
 
 import Theme 1.0
 
-// Notes on line numbering: The editor displays macro expansions inline which
-// means that code below a macroBar expansion that was expanded (i.e. is
-// visible) has to be offset in order to accomodate the macro expansion's code.
-// To do this, blank lines are inserted. These blank lines however are not
-// considered actual lines for the user. So as far as line numbering is
-// concerened, these blank lines have the same line number as the line above
-// them. These kind of line numbers are called "display line numbers". The
-// Parser module and Core module however do not know about that kind of line
-// numbering. They use the normal line numbering that assign a sequential line
-// number even to macro blank lines. These kind of line numbers are called "raw
-// line numbers". QML interface components index their line numbers starting
-// from 0.
-//
-// The following naming conventions are (mostly) used in this file:
-// - Display Line Numbers: Values from 1 to m with macro
-// blank lines factored out
-// (e.g. blank lines have same line number as line above). A variable referring
-// to lines not specified to be display or raw is usually type display (i.e.
-// display is default).
-// - Raw Line Numbers: Values from 1 to n with macro blank
-// lines treated as normal lines (therefore n >= m).
-// - Line Indexes: Values from 0 to k. Used by QML components and often used for
-// positioning.
-//
-// The functions `convertRawLineNumberToDisplayLineNumber` and
-// `convertDisplayLineNumberToRawLineNumber` can be used to translate between
-// both types of line numbers.
-
 Column {
   id: lineNumbering
   anchors.left: errorBar.right

--- a/source/ui/Components/editor/TextRegion.qml
+++ b/source/ui/Components/editor/TextRegion.qml
@@ -54,7 +54,7 @@ TextEdit {
       textRegion.convertRawLineNumberToDisplayLineNumber(newCursorLine);
     if (cursorLine !== newCursorLine) {
       cursorLine = newCursorLine;
-      editor.cursorLineChanged(newCursorLine - 1);
+      editor.cursorLineChanged(newCursorLine);
     }
 
     updateHelpTooltip();
@@ -90,7 +90,7 @@ TextEdit {
   // Tooltips: A small '?' Symbol is placed under the cursor, if there is help
   // available. By hovering over it, the help text can be overlayed.
   function updateHelpTooltip() {
-    var help = guiProject.getCommandHelp(cursorLine - 1);
+    var help = guiProject.getCommandHelp(cursorLine);
     if (help.length === 0) {
       _toolTip.hideIcon();
       return;

--- a/source/ui/editor-component.cpp
+++ b/source/ui/editor-component.cpp
@@ -119,9 +119,9 @@ void EditorComponent::setMacroList(
     macroInformationMap["code"] =
         QString::fromStdString(macroInformation.macroCode());
     macroInformationMap["startLine"] =
-        QVariant::fromValue(macroInformation.position().startLine() - 1);
+        QVariant::fromValue(macroInformation.position().startLine());
     macroInformationMap["endLine"] =
-        QVariant::fromValue(macroInformation.position().endLine() - 1);
+        QVariant::fromValue(macroInformation.position().endLine());
     int lineCount =
         static_cast<int>(std::count(macroInformation.macroCode().begin(),
                                     macroInformation.macroCode().end(),


### PR DESCRIPTION
Closes #306 
Fix bug that would cause help tooltips and help window to show wrong instruction description.