### PR TITLE
Populate .erasim directory on startup

### DIFF
--- a/include/ui/theme.hpp
+++ b/include/ui/theme.hpp
@@ -21,6 +21,7 @@
 #define ERAGPSIM_UI_THEME_HPP
 
 #include <QByteArray>
+#include <QDir>
 #include <QHash>
 #include <QJsonObject>
 #include <QQmlPropertyMap>
@@ -115,6 +116,17 @@ class Theme : public QQmlPropertyMap {
 
   /** The singleton. */
   static Theme* _theme;
+
+  /**
+   * Attempts to copy a theme from the resource directory (located in the
+   * theme/ directory relative to the executable/working directory) into the
+   * given destination directory.
+   *
+   * \param name The name of the theme to copy.
+   * \param destination the destination directory, to copy the theme into.
+   * \return true if theme could be copied into the destination directory.
+   */
+  static bool _copyTheme(const QString& name, QDir destination);
 
   /**
    * Loads raw data from disk for a given theme.

--- a/source/ui/console-component.cpp
+++ b/source/ui/console-component.cpp
@@ -49,7 +49,7 @@ void ConsoleComponent::appendText(QString text) {
     _memoryAccess.putMemoryValueAt(_start + _length, m);
     // A nullbyte signals the last byte of the console, so we should not have
     // one inside the text.
-    if (qchar == '\0') return;
+    if (qchar == QChar{'\0'}) return;
 
     // Don't count a nullbyte as length, otherwise text can't be appended
     // afterwards!

--- a/source/ui/settings.cpp
+++ b/source/ui/settings.cpp
@@ -134,7 +134,7 @@ Settings::Json Settings::toJson() const {
 }
 
 StatusWithValue<QString> Settings::_findSettingsDirectory() {
-  const auto path = ".erasim";
+  static const auto path = ".erasim";
   auto directory = QDir::home();  // Represents an absolute path to $HOME.
 
   if (!directory.exists()) {

--- a/source/ui/settings.cpp
+++ b/source/ui/settings.cpp
@@ -134,13 +134,18 @@ Settings::Json Settings::toJson() const {
 }
 
 StatusWithValue<QString> Settings::_findSettingsDirectory() {
+  const auto path = ".erasim";
   auto directory = QDir::home();  // Represents an absolute path to $HOME.
 
   if (!directory.exists()) {
     return Status::Fail("Could not find home directory");
   }
 
-  if (!directory.cd(".erasim")) {
+  if (!directory.exists(path) && !directory.mkdir(path)) {
+    return Status::Fail("Could not create settings directory");
+  }
+
+  if (!directory.cd(path)) {
     return Status::Fail("Could not find settings directory");
   }
 

--- a/source/ui/theme.cpp
+++ b/source/ui/theme.cpp
@@ -19,7 +19,7 @@
 
 #include "ui/theme.hpp"
 
-#include <QDir>
+#include <QCoreApplication>
 #include <QIODevice>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -84,15 +84,53 @@ const QString& Theme::currentThemeName() const noexcept {
   return _currentThemeName;
 }
 
+bool Theme::_copyTheme(const QString& name, QDir destination) {
+  // Obtain the executable directory
+  QDir directory{QCoreApplication::applicationDirPath()};
+
+  if (!directory.cd("themes/" + name + ".theme")) {
+    return false;
+  }
+
+  if (!destination.mkdir(name + ".theme")) {
+    return false;
+  }
+
+  if (!destination.cd(name + ".theme")) {
+    return false;
+  }
+
+  // Copy theme files
+  for (const auto& fileInfo : directory.entryInfoList(QDir::Files)) {
+    QFile file{fileInfo.absoluteFilePath()};
+    if (!file.copy(destination.filePath(fileInfo.fileName()))) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 StatusWithValue<QByteArray> Theme::_loadThemeData(const QString& name) {
+  static const auto path = ".erasim/themes";
   auto directory = QDir::home();  // Represents an absolute path to $HOME.
 
   if (!directory.exists()) {
     return Status::Fail("Could not find home directory");
   }
 
-  if (!directory.cd(".erasim/themes/")) {
+  if (!directory.exists(path) && !directory.mkdir(path)) {
+    return Status::Fail("Could not create theme directory");
+  }
+
+  if (!directory.cd(path)) {
     return Status::Fail("Could not find theme directory");
+  }
+
+  if (!directory.exists(name + ".theme")) {
+    // Attempt to copy the theme directory. Return value ignored, because that
+    // case is handled in the subsequent if statement.
+    _copyTheme(name, directory);
   }
 
   if (!directory.cd(name + ".theme")) {

--- a/source/ui/theme.cpp
+++ b/source/ui/theme.cpp
@@ -86,7 +86,7 @@ const QString& Theme::currentThemeName() const noexcept {
 
 bool Theme::_copyTheme(const QString& name, QDir destination) {
   // Obtain the executable directory
-  QDir directory{QCoreApplication::applicationDirPath()};
+  QDir directory(QCoreApplication::applicationDirPath());
 
   if (!directory.cd("themes/" + name + ".theme")) {
     return false;
@@ -102,7 +102,7 @@ bool Theme::_copyTheme(const QString& name, QDir destination) {
 
   // Copy theme files
   for (const auto& fileInfo : directory.entryInfoList(QDir::Files)) {
-    QFile file{fileInfo.absoluteFilePath()};
+    QFile file(fileInfo.absoluteFilePath());
     if (!file.copy(destination.filePath(fileInfo.fileName()))) {
       return false;
     }


### PR DESCRIPTION
Creates the basic structure of the .erasim config folder automatically. It is assumed, that the final application executable is in the same folder as the `themes/` directory, so the default theme can be copied.
(If that's not the case, create a symlink if necessary `ln -s /path/to/project/themes ./themes`)